### PR TITLE
workflows/ci: add Python 3.11 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         python:
           - "3.10"
+          - "3.11"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: William Woodruff <william@trailofbits.com>