### PR TITLE
treewide: replace flake8 with ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 100

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint: env/pyvenv.cfg
 	. env/bin/activate && \
 		black --check $(ALL_PY_SRCS) && \
 		isort --check $(ALL_PY_SRCS) && \
-		flake8 $(ALL_PY_SRCS) && \
+		ruff $(ALL_PY_SRCS) && \
 		mypy $(PY_MODULE)
 		# TODO: Enable.
 		# interrogate -c pyproject.toml .
@@ -53,6 +53,7 @@ lint: env/pyvenv.cfg
 .PHONY: reformat
 reformat:
 	. env/bin/activate && \
+		ruff --fix $(ALL_PY_SRCS) && \
 		black $(ALL_PY_SRCS) && \
 		isort $(ALL_PY_SRCS)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ test = [
 ]
 lint = [
   "bandit",
-  "flake8",
   "black",
   "isort",
   "interrogate",
   "mypy",
+  "ruff",
   "types-requests",
 ]
 dev = [
@@ -97,3 +97,8 @@ line-length = 100
 
 [tool.coverage.run]
 omit = ["abi3audit/_vendor/*"]
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "W", "UP"]
+target-version = "py310"


### PR DESCRIPTION
Can't actually merge this yet, since `ruff` doesn't support 3.10-style pattern matching yet: https://github.com/charliermarsh/ruff/issues/282

Signed-off-by: William Woodruff <william@trailofbits.com>