### PR TITLE
Get visibilities from shared objects to use them in filtering

### DIFF
--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 # Since they are not listed in CPython's `stable_abi.toml`, we maintain them here separately.
 # For more information, see https://github.com/trailofbits/abi3audit/issues/85
 # and https://github.com/wjakob/nanobind/discussions/500.
-_ALLOWED_SYMBOL_NAMES: set[Symbol] = {Symbol(name="Py_XDECREF", visibility="hidden")}
+_ALLOWED_SYMBOLS: set[Symbol] = {Symbol(name="Py_XDECREF", visibility="local")}
 
 
 class AuditError(Exception):
@@ -118,8 +118,8 @@ def audit(so: SharedObject, assume_minimum_abi3: PyVersion = PyVersion(3, 2)) ->
                     computed = maybe_abi3.added
                 if maybe_abi3.added > baseline:
                     future_abi3_objects.add(maybe_abi3)
-            elif sym.name.startswith("Py_") or sym.name.startswith("_Py_"):
-                if sym.name not in _ALLOWED_SYMBOLS:
+            elif sym.name.startswith(("Py_", "_Py_")):
+                if sym not in _ALLOWED_SYMBOLS:
                     non_abi3_symbols.add(sym)
     except Exception as exc:
         raise AuditError(f"failed to collect symbols in shared object: {exc}")

--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -119,6 +119,10 @@ def audit(so: SharedObject, assume_minimum_abi3: PyVersion = PyVersion(3, 2)) ->
                 if maybe_abi3.added > baseline:
                     future_abi3_objects.add(maybe_abi3)
             elif sym.name.startswith(("Py", "_Py")):
+                # exclude the shared object's entry point from reports.
+                # This is always PyInit_$EXTNAME, e.g. `PyInit_foo` for foo.abi3.so.
+                if sym.name == "PyInit_" + so.path.with_suffix("").stem:
+                    continue
                 # local symbols are fine, since they are inlined functions
                 # from the CPython limited API.
                 if sym not in _ALLOWED_SYMBOLS and sym.visibility != "local":

--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 # Since they are not listed in CPython's `stable_abi.toml`, we maintain them here separately.
 # For more information, see https://github.com/trailofbits/abi3audit/issues/85
 # and https://github.com/wjakob/nanobind/discussions/500.
-_ALLOWED_SYMBOL_NAMES: set[str] = {"Py_XDECREF"}
+_ALLOWED_SYMBOL_NAMES: set[Symbol] = {Symbol(name="Py_XDECREF", visibility="hidden")}
 
 
 class AuditError(Exception):
@@ -119,7 +119,7 @@ def audit(so: SharedObject, assume_minimum_abi3: PyVersion = PyVersion(3, 2)) ->
                 if maybe_abi3.added > baseline:
                     future_abi3_objects.add(maybe_abi3)
             elif sym.name.startswith("Py_") or sym.name.startswith("_Py_"):
-                if sym.name not in _ALLOWED_SYMBOL_NAMES:
+                if sym.name not in _ALLOWED_SYMBOLS:
                     non_abi3_symbols.add(sym)
     except Exception as exc:
         raise AuditError(f"failed to collect symbols in shared object: {exc}")

--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 # or stable ABI, but in practice always appear in ABI3-compatible code.
 # Since they are not listed in CPython's `stable_abi.toml`, we maintain them here separately.
 # For more information, see https://github.com/trailofbits/abi3audit/issues/85
-# and https://github.com/wjakob/nanobind/discussions/500.
-_ALLOWED_SYMBOLS: set[Symbol] = {Symbol(name="Py_XDECREF", visibility="local")}
+# and https://github.com/wjakob/nanobind/discussions/500 .
+_ALLOWED_SYMBOLS: set[str] = {"Py_XDECREF"}
 
 
 class AuditError(Exception):
@@ -118,8 +118,10 @@ def audit(so: SharedObject, assume_minimum_abi3: PyVersion = PyVersion(3, 2)) ->
                     computed = maybe_abi3.added
                 if maybe_abi3.added > baseline:
                     future_abi3_objects.add(maybe_abi3)
-            elif sym.name.startswith(("Py_", "_Py_")):
-                if sym not in _ALLOWED_SYMBOLS:
+            elif sym.name.startswith(("Py", "_Py")):
+                # local symbols are fine, since they are inlined functions
+                # from the CPython limited API.
+                if sym not in _ALLOWED_SYMBOLS and sym.visibility != "local":
                     non_abi3_symbols.add(sym)
     except Exception as exc:
         raise AuditError(f"failed to collect symbols in shared object: {exc}")

--- a/abi3audit/_object.py
+++ b/abi3audit/_object.py
@@ -216,7 +216,10 @@ class _Dll(_SharedObjectBase):
                     if imp.name is None:
                         logger.debug(f"weird: skipping import data entry without name: {imp}")
                         continue
-                    yield Symbol(imp.name.decode())
+                    # On Windows, all present symbols are also global -
+                    # that is, __declspec(dllexport) is equal to -fvisibility=hidden
+                    # plus __attribute__((visibility(default))).
+                    yield Symbol(imp.name.decode(), visibility="global")
 
 
 SharedObject = Union[_So, _Dll, _Dylib]

--- a/abi3audit/_object.py
+++ b/abi3audit/_object.py
@@ -19,6 +19,12 @@ from abi3audit._vendor import mach_o
 logger = logging.getLogger(__name__)
 
 
+st_info_to_viz = {
+    "STB_LOCAL": "hidden",
+    "STB_GLOBAL": "default",
+}
+
+
 class SharedObjectError(Exception):
     pass
 
@@ -74,6 +80,10 @@ class _So(_SharedObjectBase):
     """
 
     def __iter__(self) -> Iterator[Symbol]:
+        def get_visibility(_sym) -> str | None:
+            elfviz = _sym.entry.st_info.bind
+            return st_info_to_viz.get(elfviz)
+
         with self._extractor.path.open(mode="rb") as io, ELFFile(io) as elf:
             # The dynamic linker on Linux uses .dynsym, not .symtab, for
             # link editing and relocation. However, an extension that was
@@ -83,12 +93,12 @@ class _So(_SharedObjectBase):
             symtab = elf.get_section_by_name(".symtab")
             if symtab is not None:
                 for sym in symtab.iter_symbols():
-                    yield Symbol(sym.name)
+                    yield Symbol(sym.name, visibility=get_visibility(sym))
 
             dynsym = elf.get_section_by_name(".dynsym")
             if dynsym is not None:
                 for sym in dynsym.iter_symbols():
-                    yield Symbol(sym.name)
+                    yield Symbol(sym.name, visibility=get_visibility(sym))
 
 
 class _Dylib(_SharedObjectBase):

--- a/test/test_audit.py
+++ b/test/test_audit.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+import requests
+
+from abi3audit._audit import audit
+from abi3audit._extract import make_spec
+
+logger = logging.getLogger("abi3audit-tests")
+
+
+WHEELHOUSE = Path(__file__).parent / "wheelhouse"
+WHEELHOUSE.mkdir(exist_ok=True)
+
+
+_PACKAGE = "cryptography"
+_VERSION = "42.0.7"
+_PY = ("cp37", "cp39")
+_PLATFORMS = (
+    "macosx_10_12_universal2",
+    "manylinux_2_17_aarch64.manylinux2014_aarch64",
+    "manylinux_2_17_x86_64.manylinux2014_x86_64",
+    "manylinux_2_28_aarch64",
+    "manylinux_2_28_x86_64",
+    "musllinux_1_1_aarch64",
+    "musllinux_1_1_x86_64",
+    "musllinux_1_2_aarch64",
+    "musllinux_1_2_x86_64",
+    "win32",
+    "win_amd64",
+)
+
+
+@dataclass(frozen=True, unsafe_hash=True)
+class Wheel:
+    package: str
+    version: str
+    python: str
+    platform: str
+
+    def download(self, url: str, integrity: str, dest: Path = WHEELHOUSE) -> Path:
+        wheel = dest / self.tag()
+        if wheel.exists():
+            logger.debug(f"serving wheel {self.tag()} directly from local path {dest}")
+            return wheel
+
+        logger.debug(f"downloading wheel {self.tag()} from URL {url} into {dest}.")
+        resp = requests.get(url, stream=True)
+        resp.raise_for_status()
+        h = hashlib.sha256()
+        with open(wheel, "wb") as wfd:
+            for chunk in resp.iter_content(chunk_size=16 * 1024):
+                h.update(chunk)
+                wfd.write(chunk)
+
+        hashval = h.hexdigest()
+        if hashval != integrity:
+            wheel.unlink()
+            raise RuntimeError(
+                f"SHA-256 hash value mismatch: expected hash {integrity}, got {hashval}"
+            )
+        return wheel
+
+    def tag(self) -> str:
+        return f"{self.package}-{self.version}-{self.python}-abi3-{self.platform}.whl"
+
+    def __str__(self):
+        return self.tag()
+
+
+class WheelLinkParser(HTMLParser):
+    def __init__(self, wheels: Iterable[Wheel]):
+        super().__init__()
+        self.wheels = {w.tag(): w for w in wheels}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str]]):
+        if tag != "a" or not attrs:
+            return
+        # href attribute is always first on PyPI simple anchor tags.
+        _, url = attrs[0]
+        wheel_and_sha = url.rsplit("/", 1)[1]
+        # URLs have the format /$WHEELTAG#sha256=$SHASUM.
+        wheeltag, integrity = wheel_and_sha.split("#", 1)
+        # split off the leading "sha256=".
+        integrity = integrity[7:]
+
+        if wheeltag in self.wheels:
+            self.wheels[wheeltag].download(url=url, integrity=integrity)
+
+
+@pytest.mark.parametrize(
+    "wheel",
+    [Wheel(_PACKAGE, _VERSION, py, platform) for py in _PY for platform in _PLATFORMS],
+    ids=str,
+)
+def test_audit_results_on_golden_wheels(wheel):
+    wheel_downloader = WheelLinkParser([wheel])
+    simple_cryptography_pypi_page = requests.get(f"https://pypi.org/simple/{_PACKAGE}/")
+    simple_cryptography_pypi_page.raise_for_status()
+    # downloads the wheels when finding the appropriate URLs in the HTML doc.
+    wheel_downloader.feed(simple_cryptography_pypi_page.content.decode())
+
+    spec = make_spec(str(WHEELHOUSE / wheel.tag()))
+    for so in spec._extractor():
+        # a trimmed version of the loop in abi3audit._cli.main().
+        result = audit(so)
+        assert bool(result), f"got non-abi3 symbols {result.non_abi3_symbols}"


### PR DESCRIPTION
This is the final step in selective auditing: Obtaining the symbol visibility info, and then deciding if this symbol is an ABI3 violation with the found visibility.

The rationale is that the non-ABI3-tagged symbols which we know can be legal are all static inline, which means they should show up as local in a symbol table.

-----------------

Currently only Linux - I took the map values from [this SO thread](https://stackoverflow.com/questions/48181509/how-to-interpret-the-st-info-field-of-elf-symbol-table-section) quoting `man elf`.

Mach-O is harder. It gives me a bunch of binary values as ints, and I'm not sure how to interpret them. The returned type for `symbol` is `NList64`, which is a Python version of this struct: https://llvm.org/doxygen/structllvm_1_1MachO_1_1nlist__64.html

According to https://en.wikipedia.org/wiki/Mach-O#LINKEDIT_Symbol_table, the visibility should be found in the symbol type value (`n_type`) - I tested on the `dockerfile` wheels mentioned in the abi3audit blog post, and got an example value of 14 (or `0b1110`) for n_type, not sure what this means.

This is very much work in progress.