### PR TITLE
fix: Create venv in configured directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ dev: $(VENV_EXISTS)
 
 $(VENV_EXISTS): pyproject.toml
 	# Create our Python 3 virtual environment
-	python -m venv env
+	python -m venv $(VENV)
 	$(VENV_BIN)/python -m pip install --upgrade pip
 	$(VENV_BIN)/python -m pip install -e .[$(INSTALL_EXTRA)]
 


### PR DESCRIPTION
The option for VENV_EXISTS was hardcoded, which might have been an oversight given that the ability to override the venv is mentioned at the top of the file.