### PR TITLE
_object: lower warning to debug

### DIFF
--- a/abi3audit/_object.py
+++ b/abi3audit/_object.py
@@ -50,7 +50,7 @@ class _SharedObjectBase:
         # filename. This doesn't tell us anything about the specific abi3 version, so
         # we assume the lowest.
         if ".abi3" in self._extractor.path.suffixes:
-            logger.warning(
+            logger.debug(
                 "no wheel to infer abi3 version from; assuming (%s)",
                 assume_lowest,
             )


### PR DESCRIPTION
This is a non-actionable warning that's primarily useful for debugging, so recategorize it.

Closes #101.