### PR TITLE
workflows/release: refactor into separate steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,33 @@ on:
 name: release
 
 jobs:
-  pypi:
-    name: upload release to PyPI
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install pypa/build
+        run: python -m pip install -U build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Store distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    name: upload distributions to PyPI
+    needs:
+      - build
     runs-on: ubuntu-latest
     permissions:
       # Used to authenticate to PyPI via OIDC.
@@ -16,18 +41,13 @@ jobs:
 
       # Used to attach signing artifacts to the published release.
       contents: write
+
     steps:
-    - uses: actions/checkout@v4
-
-    - uses: actions/setup-python@v5
+    - name: Download distributions
+      uses: actions/download-artifact@v4
       with:
-        python-version-file: pyproject.toml
-
-    - name: deps
-      run: python -m pip install -U build
-
-    - name: build
-      run: python -m build
+        name: python-package-distributions
+        path: dist/
 
     - name: publish
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Moves OIDC and other permissions out of the build step, which needs nothing.

Closes #104.